### PR TITLE
Move configurable options to a config.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ config.json
 
 # Project files
 .idea
+
+# Installed project files
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# config.json may contain project files and should be totally ignored by VCS.
+config.json
+
+# Project files
+.idea

--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@
 Scans the internet for Minecraft server ips. Used to gather the database for my server scanner discord bot (https://github.com/kgurchiek/Minecraft-Server-Scanner-Discord-Bot).
 
 ## Configuration
-There are two variables in index.js that you'll want to configure to your liking:
+Configuration is handled via a json file, `config.json`. An example `config.example.json` is provided in this repository.
+
+There are two variables in config.json that you'll want to configure to your liking:
 - **pingChunkSize:** how many ips are pinged at once. Larger numbers will make the scan faster, but will of course be harder on your computer. Make sure this number is below your max open files limit, otherwise you won't get any results.
 - **pingTimeout:** how long to wait for a ping response before deciding it isn't an active server. 1500 - 2000 is recommended.
 
-Copy the contents of templateServerList.json into serverList.json. Then go to the bottom and find where the pingChunk() function is used. Replace the ip inside with whatever ip you want to start the scan with. Then, just above that, look into the pingChunk function's code, and find where it runs a ping() funtion. After `countIP(start, i)`, there's a number (25565 by default). That's the port of the server that the scanner is searching for, you can set that to whatver you'd like. 25565 is the default Java Edition port, and 19132 is the default Bedrock Edition port, so those are recommended as they would have the most servers.
+You can also adjust **scanPort** to configure which port will be hit on each IP, and **scanBlock** to adjust which /8 block will be hit by the scanner.
+
+25565 is the default Java Edition port, and 19132 is the default Bedrock Edition port, so those are recommended as they would have the most servers.
+
+The **database** section will be passed directly to `mariadb.createPool()`. Check out [their documentation](https://mariadb.com/kb/en/getting-started-with-the-nodejs-connector/) for more information.
 
 This code requires Node.js, so make sure you have that installed.
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,11 @@
+{
+  "pingChunkSize": 5240,
+  "pingTimeout": 1500,
+  "scanPort": 25565,
+  "scanBlock": "52.0.0.0",
+  "database": {
+    "user": "mariadbuser",
+    "password": "mariadbpassword",
+    "host": "mariadbhost"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "Minecraft-Server-IP-Scanner",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "minecraft-status": "^1.1.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minecraft-status": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minecraft-status/-/minecraft-status-1.1.0.tgz",
+      "integrity": "sha512-J57Ym9+FdJj63/Dk0p5NaWp4cNSdF/Fcjxdngpjl7t5x58wS2vPN/0zvnPRKEri8vAb/gEkadQfVaMtLYYQp+A==",
+      "dependencies": {
+        "iconv-lite": "^0.5.1",
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    }
+  },
+  "dependencies": {
+    "iconv-lite": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "minecraft-status": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minecraft-status/-/minecraft-status-1.1.0.tgz",
+      "integrity": "sha512-J57Ym9+FdJj63/Dk0p5NaWp4cNSdF/Fcjxdngpjl7t5x58wS2vPN/0zvnPRKEri8vAb/gEkadQfVaMtLYYQp+A==",
+      "requires": {
+        "iconv-lite": "^0.5.1",
+        "varint": "^5.0.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "minecraft-status": "^1.1.0"
+  }
+}


### PR DESCRIPTION
I've moved the options that can be configured into a config.json file instead of having them hardcoded. Might make it easier for users to host this themselves. Also, did some codestyle fixes and added a gitignore.

Summary of changes:

- minecraft-status is a dependency, as such it has been added to package.json
- codestyle cleanups, ie using `let` instead of `var`
- .gitignore has been added to properly handle node_modules, config.json, etc
- a config.json file has been added. config.json is ignored from git to prevent leaking secrets
- but an example config.example.json is in the repository with sane defaults

That's about it!